### PR TITLE
Avoid polluting the global namespace with `type`

### DIFF
--- a/angular-chartist.js
+++ b/angular-chartist.js
@@ -3,7 +3,7 @@
 
     angularChartist.directive('chartist', function () {
         var linkFn = function (scope, elm, attrs) {
-            var data, options, responsiveOptions, selector, updateChart, deepWatchData, deepWatchOptions, deepwatch;
+            var data, options, responsiveOptions, selector, updateChart, deepWatchData, deepWatchOptions, deepwatch, type;
             data = scope.data;
             options = scope.options;
             responsiveOptions = scope.responsiveOptions;


### PR DESCRIPTION
Two charts on the same page cannot be of different types because they share the global `type` variable. This should fix the problem.
